### PR TITLE
Required changes to incorporate this ROS wrapper of lightNet-TRT into edge-auto

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ You can run LightNet-TRT as a ROS 2 node. Note that current implementation requi
 First, checkout the repository.
 
 ```bash
-mkdir lightnet_trt_ws/src -p
-cd lightnet_trt_ws/src
+mkdir ros2_ws/src -p
+cd ros2_ws/src
 git clone https://github.com/kminoda/lightNet-TRT-ROS2.git
 ```
 
-Download [weights] and place the file inside the configs directory.
+Download [weights](https://drive.google.com/file/d/1ttdVtlDiPun13EQCB4Nyls3Q8w5aXg1i/view) and place the file inside the configs directory.
 
 ```bash
 cp path/to/weights lightNet-TRT-ROS2/configs/
@@ -136,8 +136,9 @@ cp path/to/weights lightNet-TRT-ROS2/configs/
 Build the package.
 
 ```bash
-cd lightnet_trt_ws
-colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_ROS2_LIGHTNET_TRT=ON
+cd ros2_ws
+colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_ROS2_LIGHTNET_TRT=ON --packages-up-to=lightnet_trt
+source install/setup.bash
 ```
 
 You can run the node as follows.

--- a/README.md
+++ b/README.md
@@ -117,17 +117,30 @@ $ ./lightNet-TRT --flagfile ../configs/lightNet-BDD100K-det-semaseg-1280x960.txt
 
 ### Inference with ROS 2 node
 
-You can build as follows. Note that current implementation requires Autoware installed and sourced.
+You can run LightNet-TRT as a ROS 2 node. Note that current implementation requires Autoware installed and sourced.
+
+First, checkout the repository.
 
 ```bash
 mkdir lightnet_trt_ws/src -p
 cd lightnet_trt_ws/src
 git clone https://github.com/kminoda/lightNet-TRT-ROS2.git
-cd ..
+```
+
+Download [weights] and place the file inside the configs directory.
+
+```bash
+cp path/to/weights lightNet-TRT-ROS2/configs/
+```
+
+Build the package.
+
+```bash
+cd lightnet_trt_ws
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release -DBUILD_ROS2_LIGHTNET_TRT=ON
 ```
 
-Then, you can run the node as follows.
+You can run the node as follows.
 
 ```bash
 ros2 launch lightnet_trt lightnet_trt.launch.xml

--- a/launch/lightnet_trt.launch.xml
+++ b/launch/lightnet_trt.launch.xml
@@ -1,6 +1,6 @@
 <launch>
   <!-- image topic name to be subscribed -->
-  <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
+  <arg name="input/image" default="/sensing/camera/camera0/image_raw"/>
   <arg name="input/camera_info" default="/sensing/camera/camera0/camera_info"/>
 
   <!-- output topic name to be published -->
@@ -12,10 +12,10 @@
   <!-- <arg name="width" default="1280"/> -->
   <!-- <arg name="height" default="960"/> -->
 
-  <arg name="model_cfg" default="$(find-pkg-share lightnet_trt)/configs/yolov8x-BDD100K-640x640-T4-lane4cls.cfg"/>
-  <arg name="model_weights" default="$(find-pkg-share lightnet_trt)/configs/yolov8x-BDD100K-640x640-T4-lane4cls-scratch-pseudo-finetune_last.weights"/>
-  <arg name="width" default="640"/>
-  <arg name="height" default="640"/>
+  <arg name="model_cfg" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-1280x960.cfg"/>
+  <arg name="model_weights" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-1280x960.weights"/>
+  <arg name="width" default="1280"/>
+  <arg name="height" default="960"/>
   <arg name="param_path" default="$(find-pkg-share lightnet_trt)/ros_config/lightnet_trt.param.yaml"/>
 
   <group>

--- a/launch/lightnet_trt.launch.xml
+++ b/launch/lightnet_trt.launch.xml
@@ -7,13 +7,8 @@
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>
 
   <!-- path to the lightNet-TRT cfg file to be loaded -->
-  <!-- <arg name="model_cfg" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-det-semaseg-1280x960.cfg"/> -->
-  <!-- <arg name="model_weights" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-det-semaseg-1280x960.weights"/> -->
-  <!-- <arg name="width" default="1280"/> -->
-  <!-- <arg name="height" default="960"/> -->
-
-  <arg name="model_cfg" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-1280x960.cfg"/>
-  <arg name="model_weights" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-1280x960.weights"/>
+  <arg name="model_cfg" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-det-semaseg-1280x960.cfg"/>
+  <arg name="model_weights" default="$(find-pkg-share lightnet_trt)/configs/lightNet-BDD100K-det-semaseg-1280x960.weights"/>
   <arg name="width" default="1280"/>
   <arg name="height" default="960"/>
   <arg name="param_path" default="$(find-pkg-share lightnet_trt)/ros_config/lightnet_trt.param.yaml"/>


### PR DESCRIPTION
This PR is related to [this one](https://github.com/tier4/edge-auto/pull/12).

To launch lightNet from edge-auto, I added following changes.

1. launch file
  - since weights file was missing, I changed the launch file to use weights file which is accessible through README
  - the name of image input topic is set to be the same as edge-auto
2. README
  - added a procedure to download and place a weights file for lightNet-TRT